### PR TITLE
[PRO-33]: add job to get historical data and send to insights app

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -1,7 +1,6 @@
 class Account < ApplicationRecord
   include Syncable, Monetizable, Issuable
 
-  after_create :process_historical_entries, if: :processable_account_type?
   validates :name, :balance, :currency, presence: true
 
   belongs_to :family
@@ -158,8 +157,6 @@ class Account < ApplicationRecord
         entryable: Account::Valuation.new
     end
   end
-
-  private
 
   def process_historical_entries
     AccountHistoricalEntriesJob.perform_later(id)

--- a/app/models/plaid_item.rb
+++ b/app/models/plaid_item.rb
@@ -39,8 +39,9 @@ class PlaidItem < ApplicationRecord
 
     accounts.each do |account|
       account.sync_data(start_date: start_date)
+      account.process_historical_entries if account.processable_account_type?
     end
-
+    
     plaid_data
   end
 
@@ -132,4 +133,5 @@ class PlaidItem < ApplicationRecord
     def remove_plaid_item
       plaid_provider.remove_item(access_token)
     end
+
 end

--- a/app/services/historical_insights_service.rb
+++ b/app/services/historical_insights_service.rb
@@ -1,5 +1,5 @@
 class HistoricalInsightsService
-    INSIGHTS_API_URL = ENV['INSIGHTS_APP_URL'] + '/api/insights/historical'
+    INSIGHTS_API_URL = ENV['INSIGHTS_APP_URL'] + '/api/categories'
   
     def initialize(account)
       @account = account


### PR DESCRIPTION
This PR introduces a new job that fetches historical data and sends it to the insights application for further processing. The job will run periodically to ensure that the insights app has access to the latest historical data for generating accurate and relevant insights.

- Created a background job for retrieving historical financial data.
- Integrated the job with the existing pipeline to send data to the insights app.
- Ensured proper error handling and logging for data retrieval and transmission.
- This update aims to provide the insights app with timely and complete data for better analysis and decision-making.